### PR TITLE
Add npm package metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Punk Mind Map
+
+This project can be served locally using npm:
+
+```bash
+npm start
+```
+
+This starts a local web server. There are currently no automated tests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "punk-mind-map",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "serve .",
+    "test": "echo \"No tests specified\" && exit 1"
+  },
+  "devDependencies": {
+    "serve": "^14.0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with dev server and placeholder tests
- add README instructions for running the local server and note lack of tests

## Testing
- `npm test` *(fails: No tests specified)*
- `npm start` *(fails: serve not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684006b3a558832f8744b49adc9839e0